### PR TITLE
fix selection rounding in stars

### DIFF
--- a/AXRatingView/AXRatingView.m
+++ b/AXRatingView/AXRatingView.m
@@ -186,7 +186,7 @@
   CGPoint location = [[touches anyObject] locationInView:self];
   float value = location.x / (_markImage.size.width * _numberOfStar) * _numberOfStar;
   if (_stepInterval != 0.0) {
-    value = roundf(value / _stepInterval) * _stepInterval;
+    value = ceilf(value / _stepInterval) * _stepInterval;
   }
   [self setValue:value];
 }


### PR DESCRIPTION
I think the step-intervals should be rounded up during calculations i.e. 2.1 step-intervals should be considered 3 step-intervals to make the ui more intuitive. If i'm tapping on 4.3 stars, I am meaning to achieve 4.5 stars on a 0.5 step size (not 4.0 stars which is current behavior).
