### PR TITLE
Allow changing the highlight colour

### DIFF
--- a/AXRatingView/AXRatingView.m
+++ b/AXRatingView/AXRatingView.m
@@ -121,6 +121,15 @@
   [self setNeedsDisplay];
 }
 
+- (void)setHighlightColor:(UIColor *)highlightColor
+{
+	_highlightColor = highlightColor;
+	[_highlightLayer removeFromSuperlayer];
+	[_starMaskLayer removeFromSuperlayer];
+	_highlightLayer = nil;
+	_starMaskLayer = nil;
+}
+
 - (void)setMarkFont:(UIFont *)markFont
 {
   _markFont = markFont;


### PR DESCRIPTION
Currently when I change the highlight colour it doesn't change from what it was originally set to.

Removing the cached CALayers forces them to be regenerated again when drawn allowing the colour to be updated.
