### PR TITLE
Value changed triggered only on control change

### DIFF
--- a/AXRatingView/AXRatingView.m
+++ b/AXRatingView/AXRatingView.m
@@ -111,7 +111,6 @@
 {
   _value = MIN(MAX(value, 0.0), _numberOfStar);
   [self setNeedsDisplay];
-  [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 - (void)setBaseColor:(UIColor *)baseColor
@@ -198,6 +197,7 @@
     value = ceilf(value / _stepInterval) * _stepInterval;
   }
   [self setValue:value];
+  [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 @end


### PR DESCRIPTION
Currently this control behaves differently to default iOS controls such as UISlider.  When AXRatingView value is set from code it will currently trigger UIControlEventValueChanged; this is not how UISlider works.

UISlider will only trigger value changed event when user interacts with the control to change its value.

UIControl class reference documentation states the following.
"UIControlEventValueChanged: A touch dragging or otherwise manipulating a control, causing it to emit a series of different values."

This commit ensures that UIControlEventValueChanged is only triggered when the value is changed through user interaction.

Also given the potential to break backwards compatibility for some users, if you choose to accept this change it should probably be part of a minor release and not a dot release.
